### PR TITLE
Fix hail plotting threshold

### DIFF
--- a/hailmap-main 2/mesh_gui.py
+++ b/hailmap-main 2/mesh_gui.py
@@ -10,7 +10,6 @@ from geopy.geocoders import Nominatim
 import boto3
 from process_mesh import load_mesh
 from mesh_utils import make_figure, save_figure, save_overlay
-from mesh_utils import make_figure, save_figure
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 OUTPUT_DIR = os.path.join(os.path.dirname(__file__), 'output')
@@ -104,12 +103,6 @@ class MeshApp(tk.Tk):
             self.toolbar = NavigationToolbar2Tk(self.canvas, self)
             self.toolbar.update()
             self.toolbar.pack(side=tk.TOP, fill=tk.X)
-            self.fig = make_figure(lats, lons, data, pin=self.pin)
-            if self.canvas:
-                self.canvas.get_tk_widget().destroy()
-            self.canvas = FigureCanvasTkAgg(self.fig, master=self)
-            self.canvas.draw()
-            self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
         except Exception as exc:
             messagebox.showerror('Error', str(exc))
 

--- a/hailmap-main 2/mesh_utils/hail_plot.py
+++ b/hailmap-main 2/mesh_utils/hail_plot.py
@@ -13,6 +13,7 @@ from process_mesh import load_mesh
 
 def make_figure(lats, lons, data, pin: Optional[Tuple[float, float]] = None):
     """Return a Matplotlib figure showing the hail swath."""
+    data = np.where(data >= 2, data, np.nan)
     fig, ax = plt.subplots(figsize=(8, 6))
     mesh = ax.pcolormesh(lons, lats, data, cmap='turbo', shading='auto')
     fig.colorbar(mesh, ax=ax, label='MESH (inches)')
@@ -29,6 +30,7 @@ def save_figure(fig, path: str):
 
 def save_overlay(lats, lons, data, path: str):
     """Save transparent image for use as map overlay."""
+    data = np.where(data >= 2, data, np.nan)
     fig, ax = plt.subplots(figsize=(8, 6))
     mesh = ax.pcolormesh(lons, lats, data, cmap='turbo', shading='auto')
     ax.axis('off')
@@ -40,6 +42,7 @@ def save_overlay(lats, lons, data, path: str):
 
 def save_geotiff(lats, lons, data, path: str):
     """Save data array to GeoTIFF with geographic bounds."""
+    data = np.where(data >= 2, data, 0)
     transform = from_bounds(float(lons.min()), float(lats.min()),
                             float(lons.max()), float(lats.max()),
                             data.shape[1], data.shape[0])
@@ -59,6 +62,7 @@ def save_geotiff(lats, lons, data, path: str):
 
 def make_contour(lats, lons, data, pin: Optional[Tuple[float, float]] = None):
     """Return a Matplotlib figure with contour lines."""
+    data = np.where(data >= 2, data, np.nan)
     fig, ax = plt.subplots(figsize=(8, 6))
     cs = ax.contour(lons, lats, data, colors='k')
     ax.clabel(cs, inline=1, fontsize=8)
@@ -74,6 +78,7 @@ def save_animation(files: List[str], path: str, pin: Optional[Tuple[float, float
     frames = []
     for f in files:
         lats, lons, data = load_mesh(f)
+        data = np.where(data >= 2, data, np.nan)
         fig = make_figure(lats, lons, data, pin=pin)
         frames.append([plt.imshow(data, animated=True)])
         plt.close(fig)

--- a/mesh_gui.py
+++ b/mesh_gui.py
@@ -10,7 +10,6 @@ from geopy.geocoders import Nominatim
 import boto3
 from process_mesh import load_mesh
 from mesh_utils import make_figure, save_figure, save_overlay
-from mesh_utils import make_figure, save_figure
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 OUTPUT_DIR = os.path.join(os.path.dirname(__file__), 'output')
@@ -104,12 +103,6 @@ class MeshApp(tk.Tk):
             self.toolbar = NavigationToolbar2Tk(self.canvas, self)
             self.toolbar.update()
             self.toolbar.pack(side=tk.TOP, fill=tk.X)
-            self.fig = make_figure(lats, lons, data, pin=self.pin)
-            if self.canvas:
-                self.canvas.get_tk_widget().destroy()
-            self.canvas = FigureCanvasTkAgg(self.fig, master=self)
-            self.canvas.draw()
-            self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
         except Exception as exc:
             messagebox.showerror('Error', str(exc))
 

--- a/mesh_utils/hail_plot.py
+++ b/mesh_utils/hail_plot.py
@@ -13,6 +13,8 @@ from process_mesh import load_mesh
 
 def make_figure(lats, lons, data, pin: Optional[Tuple[float, float]] = None):
     """Return a Matplotlib figure showing the hail swath."""
+    # mask values below 2 to avoid plotting insignificant hail sizes
+    data = np.where(data >= 2, data, np.nan)
     fig, ax = plt.subplots(figsize=(8, 6))
     mesh = ax.pcolormesh(lons, lats, data, cmap='turbo', shading='auto')
     fig.colorbar(mesh, ax=ax, label='MESH (inches)')
@@ -29,6 +31,7 @@ def save_figure(fig, path: str):
 
 def save_overlay(lats, lons, data, path: str):
     """Save transparent image for use as map overlay."""
+    data = np.where(data >= 2, data, np.nan)
     fig, ax = plt.subplots(figsize=(8, 6))
     mesh = ax.pcolormesh(lons, lats, data, cmap='turbo', shading='auto')
     ax.axis('off')
@@ -40,6 +43,7 @@ def save_overlay(lats, lons, data, path: str):
 
 def save_geotiff(lats, lons, data, path: str):
     """Save data array to GeoTIFF with geographic bounds."""
+    data = np.where(data >= 2, data, 0)
     transform = from_bounds(float(lons.min()), float(lats.min()),
                             float(lons.max()), float(lats.max()),
                             data.shape[1], data.shape[0])
@@ -59,6 +63,7 @@ def save_geotiff(lats, lons, data, path: str):
 
 def make_contour(lats, lons, data, pin: Optional[Tuple[float, float]] = None):
     """Return a Matplotlib figure with contour lines."""
+    data = np.where(data >= 2, data, np.nan)
     fig, ax = plt.subplots(figsize=(8, 6))
     cs = ax.contour(lons, lats, data, colors='k')
     ax.clabel(cs, inline=1, fontsize=8)
@@ -74,6 +79,7 @@ def save_animation(files: List[str], path: str, pin: Optional[Tuple[float, float
     frames = []
     for f in files:
         lats, lons, data = load_mesh(f)
+        data = np.where(data >= 2, data, np.nan)
         fig = make_figure(lats, lons, data, pin=pin)
         frames.append([plt.imshow(data, animated=True)])
         plt.close(fig)


### PR DESCRIPTION
## Summary
- filter out hail values under 2 inches before plotting
- clean up duplicate imports and figure creation in the GUI

## Testing
- `pytest -q tests/test_process.py`
- `pytest -q 'hailmap-main 2/tests/test_process.py'`


------
https://chatgpt.com/codex/tasks/task_b_68459a54509c833189339b595b68c0a8