### PR TITLE
Handle gz decompress in load_mesh

### DIFF
--- a/hailmap-main 2/process_mesh.py
+++ b/hailmap-main 2/process_mesh.py
@@ -7,28 +7,27 @@ import xarray as xr
 
 
 def _open_dataset(path: str):
-    """Open a hail dataset. Supports NetCDF and GRIB2."""
-    if path.endswith('.grib2'):
-        return xr.open_dataset(path, engine='cfgrib')
-
-    if path.endswith('.gz'):
-        tmp_path = path[:-3]
-        with gzip.open(path, 'rb') as f_in, open(tmp_path, 'wb') as f_out:
-            f_out.write(f_in.read())
-        ds = Dataset(tmp_path)
-        os.remove(tmp_path)
-    else:
-        ds = Dataset(path)
-    return ds
+    """Open an uncompressed hail dataset."""
+    if path.endswith(".grib2"):
+        return xr.open_dataset(path, engine="cfgrib")
+    return Dataset(path)
 
 
 def load_mesh(path: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Return lat, lon, mesh arrays from a MRMS MESH file."""
-    ds = _open_dataset(path)
+    tmp_path = None
+    open_path = path
+    if path.endswith(".gz"):
+        tmp_path = path[:-3]
+        with gzip.open(path, "rb") as f_in, open(tmp_path, "wb") as f_out:
+            f_out.write(f_in.read())
+        open_path = tmp_path
+
+    ds = _open_dataset(open_path)
 
     var_candidates = ['MESH', 'MaxEstimatedHailSize', 'value']
 
-    if path.endswith('.grib2'):
+    if open_path.endswith('.grib2'):
         var_name = None
         for name in var_candidates:
             if name in ds.data_vars:
@@ -42,6 +41,8 @@ def load_mesh(path: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         lats = np.array(lat_obj.values)
         lons = np.array(lon_obj.values)
         ds.close()
+        if tmp_path:
+            os.remove(tmp_path)
         return lats, lons, data
 
     # netCDF path
@@ -57,4 +58,6 @@ def load_mesh(path: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     lats = np.array(ds.variables.get('Latitude', ds.variables.get('lat'))[:])
     lons = np.array(ds.variables.get('Longitude', ds.variables.get('lon'))[:])
     ds.close()
+    if tmp_path:
+        os.remove(tmp_path)
     return lats, lons, data

--- a/process_mesh.py
+++ b/process_mesh.py
@@ -7,28 +7,27 @@ import xarray as xr
 
 
 def _open_dataset(path: str):
-    """Open a hail dataset. Supports NetCDF and GRIB2."""
-    if path.endswith('.grib2'):
-        return xr.open_dataset(path, engine='cfgrib')
-
-    if path.endswith('.gz'):
-        tmp_path = path[:-3]
-        with gzip.open(path, 'rb') as f_in, open(tmp_path, 'wb') as f_out:
-            f_out.write(f_in.read())
-        ds = Dataset(tmp_path)
-        os.remove(tmp_path)
-    else:
-        ds = Dataset(path)
-    return ds
+    """Open an uncompressed hail dataset."""
+    if path.endswith(".grib2"):
+        return xr.open_dataset(path, engine="cfgrib")
+    return Dataset(path)
 
 
 def load_mesh(path: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Return lat, lon, mesh arrays from a MRMS MESH file."""
-    ds = _open_dataset(path)
+    tmp_path = None
+    open_path = path
+    if path.endswith(".gz"):
+        tmp_path = path[:-3]
+        with gzip.open(path, "rb") as f_in, open(tmp_path, "wb") as f_out:
+            f_out.write(f_in.read())
+        open_path = tmp_path
+
+    ds = _open_dataset(open_path)
 
     var_candidates = ['MESH', 'MaxEstimatedHailSize', 'value']
 
-    if path.endswith('.grib2'):
+    if open_path.endswith('.grib2'):
         var_name = None
         for name in var_candidates:
             if name in ds.data_vars:
@@ -42,6 +41,8 @@ def load_mesh(path: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         lats = np.array(lat_obj.values)
         lons = np.array(lon_obj.values)
         ds.close()
+        if tmp_path:
+            os.remove(tmp_path)
         return lats, lons, data
 
     # netCDF path
@@ -57,4 +58,6 @@ def load_mesh(path: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     lats = np.array(ds.variables.get('Latitude', ds.variables.get('lat'))[:])
     lons = np.array(ds.variables.get('Longitude', ds.variables.get('lon'))[:])
     ds.close()
+    if tmp_path:
+        os.remove(tmp_path)
     return lats, lons, data


### PR DESCRIPTION
## Summary
- support loading gzipped MESH files
- factor `_open_dataset` to open only uncompressed files
- mirror implementation in both `process_mesh.py` copies

## Testing
- `pytest tests/test_process.py -q`
- `pytest 'hailmap-main 2/tests/test_process.py' -q`


------
https://chatgpt.com/codex/tasks/task_b_6845a860223c8331adcce7046681c5af